### PR TITLE
Set artworks feed images size to 400 from 843.

### DIFF
--- a/Essential Art App/Essential Art AppTests/ArtworksListAcceptanceTests.swift
+++ b/Essential Art App/Essential Art AppTests/ArtworksListAcceptanceTests.swift
@@ -120,11 +120,13 @@ class ArtworksListAcceptanceTests: XCTestCase {
 
 	private let baseURL = URL(string: "http://url-0.com")!
 
+	private let artworksFeedImageSize: Int = 400
+
 	lazy var imageDataForURLPath: [String: Data] = [
-		"/0123/full/843,/0/default.jpg": imageData0,
-		"/3273/full/843,/0/default.jpg": imageData1,
-		"/32923/full/843,/0/default.jpg": imageData2,
-		"/44944/full/843,/0/default.jpg": imageData3
+		"/0123/full/\(artworksFeedImageSize),/0/default.jpg": imageData0,
+		"/3273/full/\(artworksFeedImageSize),/0/default.jpg": imageData1,
+		"/32923/full/\(artworksFeedImageSize),/0/default.jpg": imageData2,
+		"/44944/full/\(artworksFeedImageSize),/0/default.jpg": imageData3
 	]
 
 	private func artworkWithImageID(_ imageID: String, customID: Int? = nil) -> [String: Any] {

--- a/Essential Art/Essential Art API EndToEnd Tests/Essential_Art_API_EndToEnd_Tests.swift
+++ b/Essential Art/Essential Art API EndToEnd Tests/Essential_Art_API_EndToEnd_Tests.swift
@@ -56,7 +56,7 @@ class Essential_Art_API_EndToEnd_Tests: XCTestCase {
 	]
 
 	private func imageURLForID(_ id: String) -> URL {
-		return URL(string: "https://www.artic.edu/iiif/2/" + id + "/full/843,/0/default.jpg")!
+		return URL(string: "https://www.artic.edu/iiif/2/" + id + "/full/400,/0/default.jpg")!
 	}
 
 	private var baseURL = URL(string: "https://api.artic.edu")!

--- a/Essential Art/Essential Art Tests/Artic API/ArtworkMapperTests.swift
+++ b/Essential Art/Essential Art Tests/Artic API/ArtworkMapperTests.swift
@@ -47,14 +47,14 @@ class ArtworkMapperTests: XCTestCase {
 			imageID: "1234",
 			title: "Any title",
 			baseURL: baseURL,
-			urlSuffix: "full/843,/0/default.jpg",
+			urlSuffix: "full/400,/0/default.jpg",
 			artist: "A famous one")
 
 		let artwork2 = makeArtwork(
 			imageID: "5678",
 			title: "The art of programming",
 			baseURL: baseURL,
-			urlSuffix: "full/843,/0/default.jpg",
+			urlSuffix: "full/400,/0/default.jpg",
 			artist: "Unknown artist")
 
 		let json = makeArtworksJSON([artwork1.json, artwork2.json], baseURL: baseURL)

--- a/Essential Art/Essential Art/Artic API/ArtworkMapper.swift
+++ b/Essential Art/Essential Art/Artic API/ArtworkMapper.swift
@@ -59,7 +59,7 @@ public final class ArtworkMapper {
 
 			let imageURL = baseURL
 				.appendingPathComponent("/\(imageID)")
-				.appendingPathComponent("/full/843,/0/default.jpg")
+				.appendingPathComponent("/full/400,/0/default.jpg")
 
 			return Artwork(title: title, imageURL: imageURL, artist: artist, id: id)
 		}


### PR DESCRIPTION
This facilitates image loading, reduces size of the app in cache and does not affect UX, as image keep looking in high quality at the current cell sizes